### PR TITLE
Add macOS build support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,5 +15,4 @@ case "$(uname -s)" in
   ;;
 esac
 
-${JOBS="$corecount"}
-make -j"$JOBS"
+make -j"$corecount"

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,14 @@
 ./scripts/install-hextype-files.sh
 
 # build HexType
-corecount="`grep '^processor' /proc/cpuinfo|wc -l`"
+case "$(uname -s)" in
+  Darwin)
+  corecount="$(sysctl -n hw.ncpu)"
+  ;;
+  *)
+  corecount="$(`grep '^processor' /proc/cpuinfo|wc -l`)"
+  ;;
+esac
+
 ${JOBS="$corecount"}
 make -j"$JOBS"


### PR DESCRIPTION
I've added a case call for the build.sh. This builds on my macOS 10.13 laptop and should continue to work on linux/bsd/haiku/whatever.